### PR TITLE
fix invalid token header and hashbang crash

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -16,7 +16,7 @@ const api = axios.create({
 api.interceptors.request.use(
   (config) => {
     const token = localStorage.getItem("access");
-    if (token) {
+    if (token && token !== "null" && token !== "undefined") {
       config.headers.Authorization = `Bearer ${token}`;
     }
     return config;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -6,6 +6,14 @@ import reportWebVitals from './reportWebVitals';
 import 'materialize-css/dist/css/materialize.min.css';
 import 'materialize-css/dist/js/materialize.min.js';
 
+// Materialize tries to query the current hash on load. When the hash is "#!"
+// (a common placeholder), this results in an invalid CSS selector and crashes
+// the app. Clear such hashbangs before rendering to keep initialization safe.
+if (window.location.hash === '#!') {
+  const { pathname, search } = window.location;
+  window.history.replaceState(null, '', pathname + search);
+}
+
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- ignore `null` or `undefined` tokens when attaching Authorization headers
- strip `#!` hash from URL to avoid Materialize selector crash

## Testing
- `CI=true npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: request to http://127.0.0.1:8000/ ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d10889588331b19f0d7db80b95f5