### PR TITLE
fix invalid token header and hashbang crash

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -16,12 +16,49 @@ const api = axios.create({
 api.interceptors.request.use(
   (config) => {
     const token = localStorage.getItem("access");
-    if (token) {
+    if (token && token !== "null" && token !== "undefined") {
       config.headers.Authorization = `Bearer ${token}`;
     }
     return config;
   },
   (error) => Promise.reject(error)
+);
+
+// Автоматическое обновление access-токена при получении 401
+api.interceptors.response.use(
+  (res) => res,
+  async (error) => {
+    const original = error.config;
+    const status = error.response ? error.response.status : null;
+
+    if (status === 401 && !original._retry) {
+      original._retry = true;
+      const refresh = localStorage.getItem("refresh");
+
+      if (refresh) {
+        try {
+          const { data } = await axios.post(
+            "http://127.0.0.1:8000/api/token/refresh/",
+            { refresh }
+          );
+          localStorage.setItem("access", data.access);
+          original.headers.Authorization = `Bearer ${data.access}`;
+          return api(original);
+        } catch (refreshErr) {
+          localStorage.removeItem("access");
+          localStorage.removeItem("refresh");
+          window.location.href = "/login";
+          return Promise.reject(refreshErr);
+        }
+      }
+
+      localStorage.removeItem("access");
+      localStorage.removeItem("refresh");
+      window.location.href = "/login";
+    }
+
+    return Promise.reject(error);
+  }
 );
 
 export default api;

--- a/frontend/src/components/Profile.js
+++ b/frontend/src/components/Profile.js
@@ -41,7 +41,7 @@ function Profile() {
       formData.append("photo", profile.photo);
     }
     try {
-      const res = await api.patch("accounts/profile/", formData, {
+      const res = await api.put("accounts/profile/", formData, {
         headers: { "Content-Type": "multipart/form-data" },
       });
       setProfile(res.data);

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -6,6 +6,14 @@ import reportWebVitals from './reportWebVitals';
 import 'materialize-css/dist/css/materialize.min.css';
 import 'materialize-css/dist/js/materialize.min.js';
 
+// Materialize tries to query the current hash on load. When the hash is "#!"
+// (a common placeholder), this results in an invalid CSS selector and crashes
+// the app. Clear such hashbangs before rendering to keep initialization safe.
+if (window.location.hash === '#!') {
+  const { pathname, search } = window.location;
+  window.history.replaceState(null, '', pathname + search);
+}
+
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- ignore `null` or `undefined` tokens when attaching Authorization headers
- strip `#!` hash from URL to avoid Materialize selector crash
- automatically refresh JWT on 401 and redirect to login if refresh fails
- send profile updates with `PUT` instead of `PATCH`

## Testing
- `npm_config_http_proxy= npm_config_https_proxy= timeout 30 npm install --registry=https://registry.npmjs.org` *(hangs, process terminated)*
- `CI=true npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d10889588331b19f0d7db80b95f5