### PR TITLE
feat(profile): просмотр/редактирование профиля, показ фото и данных

### DIFF
--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -2,6 +2,7 @@
 # Путь: backend/accounts/serializers.py
 # Назначение: сериализаторы для регистрации и профиля пользователей.
 
+# backend/accounts/serializers.py
 from rest_framework import serializers
 from django.contrib.auth import get_user_model
 from django.contrib.auth.password_validation import validate_password
@@ -10,7 +11,18 @@ User = get_user_model()
 
 
 class UserSerializer(serializers.ModelSerializer):
-    """Сериализатор профиля пользователя (просмотр/редактирование)."""
+    """
+    Сериализатор профиля пользователя (просмотр/редактирование).
+    - read_only: поля, которые нельзя менять с фронта (id, username, is_staff, email — при желании можно открыть email).
+    - все редактируемые поля НЕ обязательны (required=False), чтобы PATCH/PUT не валились 400.
+    - photo поддерживает multipart и может быть опциональной.
+    """
+
+    # можно явно поменять типы опциональных полей
+    first_name = serializers.CharField(required=False, allow_blank=True)
+    last_name = serializers.CharField(required=False, allow_blank=True)
+    bio = serializers.CharField(required=False, allow_blank=True)
+    photo = serializers.ImageField(required=False, allow_null=True)
 
     class Meta:
         model = User
@@ -24,19 +36,37 @@ class UserSerializer(serializers.ModelSerializer):
             "bio",
             "is_staff",
         ]
+        read_only_fields = ("id", "username", "is_staff", "email")  # если нужно редактировать email — убери отсюда
+
+    def update(self, instance, validated_data):
+        """
+        Доп. поведение:
+        - Если фронт хочет очистить фото, можно передать photo=null (JSON) или не передавать поле вовсе.
+        """
+        # Очистка фото: разрешим явный null
+        if "photo" in self.initial_data and self.initial_data.get("photo") in (None, "null", ""):
+            instance.photo.delete(save=False)
+            validated_data.pop("photo", None)
+
+        return super().update(instance, validated_data)
 
 
 class RegisterSerializer(serializers.ModelSerializer):
-    """Сериализатор регистрации нового автора."""
-
+    """
+    Сериализатор регистрации нового автора.
+    """
     password = serializers.CharField(
         write_only=True,
         required=True,
         validators=[validate_password],
     )
     password2 = serializers.CharField(write_only=True, required=True)
+
+    # опциональные поля профиля
     photo = serializers.ImageField(required=False, allow_null=True)
     bio = serializers.CharField(required=False, allow_blank=True)
+    first_name = serializers.CharField(required=False, allow_blank=True)
+    last_name = serializers.CharField(required=False, allow_blank=True)
 
     class Meta:
         model = User
@@ -58,5 +88,6 @@ class RegisterSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         validated_data.pop("password2")
+        # create_user сам захэширует пароль и обработает обязательные поля модели
         user = User.objects.create_user(**validated_data)
         return user

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -1,8 +1,7 @@
 # backend/accounts/views.py
-# Путь: backend/accounts/views.py
-# Назначение: API-представления для регистрации и управления профилем авторов.
-
-from rest_framework import generics, permissions
+from rest_framework import generics, permissions, status
+from rest_framework.response import Response
+from rest_framework.parsers import JSONParser, FormParser, MultiPartParser
 from django.contrib.auth import get_user_model
 from .serializers import UserSerializer, RegisterSerializer
 
@@ -11,16 +10,33 @@ User = get_user_model()
 
 class RegisterView(generics.CreateAPIView):
     """Регистрация нового пользователя."""
-
     queryset = User.objects.all()
     serializer_class = RegisterSerializer
+    permission_classes = [permissions.AllowAny]
 
 
 class ProfileView(generics.RetrieveUpdateAPIView):
-    """Просмотр и редактирование профиля текущего пользователя."""
-
+    """
+    Просмотр и редактирование профиля текущего пользователя.
+    Поддерживает PATCH (частичное обновление), а также multipart/form-data (например, avatar).
+    """
     serializer_class = UserSerializer
     permission_classes = [permissions.IsAuthenticated]
+    parser_classes = [JSONParser, FormParser, MultiPartParser]
 
     def get_object(self):
         return self.request.user
+
+    # ЯВНО обрабатываем PATCH как partial=True
+    def patch(self, request, *args, **kwargs):
+        serializer = self.get_serializer(self.get_object(), data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        self.perform_update(serializer)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    # PUT тоже делаем "partial", чтобы фронту не требовались все поля сразу
+    def put(self, request, *args, **kwargs):
+        serializer = self.get_serializer(self.get_object(), data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        self.perform_update(serializer)
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,64 +1,144 @@
-// ===== ФАЙЛ: frontend/src/api.js =====
-// ПУТЬ: C:\Users\ASUS Vivobook\PycharmProjects\izotovlife\frontend\src\api.js
-// НАЗНАЧЕНИЕ: Конфигурация API для фронтенда (React ↔ Django backend)
+// ===== frontend/src/api.js =====
+// Единый axios-клиент + очереди для безопасного refresh токена
 
 import axios from "axios";
 
-// Базовый URL всегда указывает на Django (порт 8000)
+const API_BASE = "http://127.0.0.1:8000/api/";
+
+// Единый экземпляр клиента
 const api = axios.create({
-  baseURL: "http://127.0.0.1:8000/api/",
-  headers: {
-    "Content-Type": "application/json",
-  },
+  baseURL: API_BASE,
+  headers: { "Content-Type": "application/json" },
 });
 
-// Перехватчик для подстановки JWT токена (если есть)
+// --- Хранилище токенов ---
+function getAccess() {
+  const t = localStorage.getItem("access");
+  return t && t !== "null" && t !== "undefined" ? t : null;
+}
+function getRefresh() {
+  const t = localStorage.getItem("refresh");
+  return t && t !== "null" && t !== "undefined" ? t : null;
+}
+function setAccess(token) {
+  localStorage.setItem("access", token);
+}
+function clearTokens() {
+  localStorage.removeItem("access");
+  localStorage.removeItem("refresh");
+}
+
+// --- Мьютекс для refresh, чтобы не было лавины запросов ---
+let isRefreshing = false;
+let refreshQueue = []; // массив промис-резолверов
+
+function subscribeTokenRefresh(cb) {
+  refreshQueue.push(cb);
+}
+function onRefreshed(newAccess) {
+  refreshQueue.forEach((cb) => cb(newAccess));
+  refreshQueue = [];
+}
+
+// --- Request: подставляем Bearer ---
 api.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem("access");
-    if (token && token !== "null" && token !== "undefined") {
-      config.headers.Authorization = `Bearer ${token}`;
+    const access = getAccess();
+    if (access) {
+      config.headers.Authorization = `Bearer ${access}`;
     }
     return config;
   },
   (error) => Promise.reject(error)
 );
 
-// Автоматическое обновление access-токена при получении 401
+// Функция рефреша (единственная «владеет» сетевым вызовом)
+async function refreshAccessToken() {
+  const refresh = getRefresh();
+  if (!refresh) throw new Error("No refresh token");
+
+  const { data } = await axios.post(`${API_BASE}token/refresh/`, { refresh });
+  // Ожидаем, что backend возвращает { access, refresh? }
+  if (data?.access) setAccess(data.access);
+  return data?.access;
+}
+
+// --- Response: перехват 401 с очередью ---
 api.interceptors.response.use(
   (res) => res,
   async (error) => {
-    const original = error.config;
-    const status = error.response ? error.response.status : null;
+    const status = error?.response?.status;
+    const original = error?.config;
 
-    if (status === 401 && !original._retry) {
-      original._retry = true;
-      const refresh = localStorage.getItem("refresh");
-
-      if (refresh) {
-        try {
-          const { data } = await axios.post(
-            "http://127.0.0.1:8000/api/token/refresh/",
-            { refresh }
-          );
-          localStorage.setItem("access", data.access);
-          original.headers.Authorization = `Bearer ${data.access}`;
-          return api(original);
-        } catch (refreshErr) {
-          localStorage.removeItem("access");
-          localStorage.removeItem("refresh");
-          window.location.href = "/login";
-          return Promise.reject(refreshErr);
-        }
-      }
-
-      localStorage.removeItem("access");
-      localStorage.removeItem("refresh");
-      window.location.href = "/login";
+    // Если не 401 — отдать как есть
+    if (status !== 401 || original?._retry) {
+      return Promise.reject(error);
     }
 
-    return Promise.reject(error);
+    // Помечаем, что этот запрос уже будет повторён один раз
+    original._retry = true;
+
+    // Если уже идёт refresh — подпишемся и дождёмся
+    if (isRefreshing) {
+      return new Promise((resolve, reject) => {
+        subscribeTokenRefresh((newAccess) => {
+          if (newAccess) {
+            original.headers.Authorization = `Bearer ${newAccess}`;
+            resolve(api(original));
+          } else {
+            reject(error);
+          }
+        });
+      });
+    }
+
+    // Мы первые: запускаем refresh
+    isRefreshing = true;
+    try {
+      const newAccess = await refreshAccessToken();
+      isRefreshing = false;
+      onRefreshed(newAccess);
+      // повторим оригинальный запрос
+      if (newAccess) {
+        original.headers.Authorization = `Bearer ${newAccess}`;
+      }
+      return api(original);
+    } catch (refreshErr) {
+      isRefreshing = false;
+      onRefreshed(null); // разбудим ожидающих с неуспехом
+      clearTokens();
+      // один редирект на всех
+      if (window.location.pathname !== "/login") {
+        window.location.replace("/login");
+      }
+      return Promise.reject(refreshErr);
+    }
   }
 );
 
 export default api;
+
+// (опционально) удобные обёртки для сервисов:
+export const AccountsAPI = {
+  getProfile: () => api.get("accounts/profile/"),
+  updateProfile: (payload) => api.patch("accounts/profile/", payload), // PATCH для частичных обновлений
+};
+
+export const AuthAPI = {
+  login: async (username, password) => {
+    const { data } = await axios.post(`${API_BASE}token/`, { username, password });
+    if (data?.access) localStorage.setItem("access", data.access);
+    if (data?.refresh) localStorage.setItem("refresh", data.refresh);
+    return data;
+  },
+  logout: () => {
+    clearTokens();
+    window.location.replace("/login");
+  },
+};
+
+export const NewsAPI = {
+  list: (page = 1) => api.get(`news/?page=${page}`),
+  popular: () => api.get("news/popular/"),
+  detail: (id) => api.get(`news/${id}/`),
+};

--- a/frontend/src/components/Profile.js
+++ b/frontend/src/components/Profile.js
@@ -1,101 +1,236 @@
 // frontend/src/components/Profile.js
-// Путь: frontend/src/components/Profile.js
-// Назначение: просмотр и редактирование профиля автора.
+// Просмотр и редактирование профиля автора (режимы: view/edit)
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import api from "../api";
 
 function Profile() {
   const [profile, setProfile] = useState(null);
   const [loading, setLoading] = useState(true);
 
+  const [edit, setEdit] = useState(false);
+  const [form, setForm] = useState({ first_name: "", last_name: "", bio: "" });
+  const [file, setFile] = useState(null);
+  const [preview, setPreview] = useState(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  // загрузка профиля
   useEffect(() => {
-    async function fetchProfile() {
+    let mounted = true;
+    (async () => {
       try {
         const res = await api.get("accounts/profile/");
+        if (!mounted) return;
         setProfile(res.data);
+        setForm({
+          first_name: res.data.first_name ?? "",
+          last_name: res.data.last_name ?? "",
+          bio: res.data.bio ?? "",
+        });
       } catch (err) {
         console.error("Ошибка загрузки профиля:", err);
       } finally {
         setLoading(false);
       }
-    }
-    fetchProfile();
+    })();
+    return () => { mounted = false; };
   }, []);
 
-  const handleChange = (e) => {
-    setProfile({ ...profile, [e.target.name]: e.target.value });
+  // превью выбранного файла
+  useEffect(() => {
+    if (!file) { setPreview(null); return; }
+    const url = URL.createObjectURL(file);
+    setPreview(url);
+    return () => URL.revokeObjectURL(url);
+  }, [file]);
+
+  const avatarSrc = useMemo(() => {
+    // сервер отдаёт абсолютный URL (см. SerializerMethodField на бэке)
+    return preview || profile?.photo || null;
+  }, [preview, profile]);
+
+  const onChange = (e) => {
+    const { name, value } = e.target;
+    setForm((s) => ({ ...s, [name]: value }));
   };
 
-  const handleFile = (e) => {
-    setProfile({ ...profile, photo: e.target.files[0] });
+  const onFile = (e) => {
+    const f = e.target.files?.[0];
+    setFile(f || null);
   };
 
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    const formData = new FormData();
-    formData.append("first_name", profile.first_name || "");
-    formData.append("last_name", profile.last_name || "");
-    formData.append("bio", profile.bio || "");
-    if (profile.photo instanceof File) {
-      formData.append("photo", profile.photo);
-    }
-    try {
-      const res = await api.put("accounts/profile/", formData, {
-        headers: { "Content-Type": "multipart/form-data" },
+  const onEdit = () => {
+    setEdit(true);
+    setError(null);
+  };
+
+  const onCancel = () => {
+    setEdit(false);
+    setError(null);
+    setFile(null);
+    setPreview(null);
+    if (profile) {
+      setForm({
+        first_name: profile.first_name ?? "",
+        last_name: profile.last_name ?? "",
+        bio: profile.bio ?? "",
       });
+    }
+  };
+
+  const onSave = async (e) => {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    try {
+      let res;
+      if (file) {
+        const fd = new FormData();
+        fd.append("first_name", form.first_name);
+        fd.append("last_name", form.last_name);
+        fd.append("bio", form.bio);
+        fd.append("photo", file);
+        // Важно: не ставим Content-Type — axios сам проставит multipart границы
+        res = await api.patch("accounts/profile/", fd);
+      } else {
+        res = await api.patch("accounts/profile/", form);
+      }
       setProfile(res.data);
-      alert("Профиль обновлён");
+      setEdit(false);
+      setFile(null);
+      setPreview(null);
     } catch (err) {
       console.error("Ошибка обновления профиля:", err);
+      setError(err?.response?.data || "Не удалось сохранить изменения");
+    } finally {
+      setSaving(false);
     }
   };
 
-  if (loading) return <p>Загрузка профиля...</p>;
+  const onRemovePhoto = async () => {
+    try {
+      const res = await api.patch("accounts/profile/", { photo: null });
+      setProfile(res.data);
+      setFile(null);
+      setPreview(null);
+    } catch (err) {
+      console.error("Ошибка удаления фото:", err);
+      setError(err?.response?.data || "Не удалось удалить фото");
+    }
+  };
+
+  if (loading) return <p>Загрузка профиля…</p>;
   if (!profile) return <p>Ошибка загрузки профиля</p>;
 
   return (
-    <div className="container">
+    <div className="container" style={{ maxWidth: 720 }}>
       <h2>Профиль</h2>
-      <p><b>Имя пользователя:</b> {profile.username}</p>
-      <p><b>Email:</b> {profile.email}</p>
-      <form onSubmit={handleSubmit}>
-        <div className="input-field">
-          <input
-            name="first_name"
-            value={profile.first_name || ""}
-            onChange={handleChange}
-          />
-          <label className="active" htmlFor="first_name">Имя</label>
-        </div>
-        <div className="input-field">
-          <input
-            name="last_name"
-            value={profile.last_name || ""}
-            onChange={handleChange}
-          />
-          <label className="active" htmlFor="last_name">Фамилия</label>
-        </div>
-        <div className="input-field">
-          <textarea
-            name="bio"
-            className="materialize-textarea"
-            value={profile.bio || ""}
-            onChange={handleChange}
-          ></textarea>
-          <label className="active" htmlFor="bio">Описание</label>
-        </div>
-        <div className="file-field input-field">
-          <div className="btn">
-            <span>Фото</span>
-            <input type="file" onChange={handleFile} />
+
+      {/* Режим просмотра (по умолчанию) */}
+      {!edit && (
+        <>
+          <div style={{ display: "flex", gap: 24, alignItems: "flex-start" }}>
+            <div>
+              {avatarSrc ? (
+                <img
+                  src={avatarSrc}
+                  alt="avatar"
+                  style={{ width: 132, height: 132, borderRadius: "50%", objectFit: "cover", border: "1px solid #eee" }}
+                />
+              ) : (
+                <div style={{ width: 132, height: 132, borderRadius: "50%", background: "#f2f2f2", display: "grid", placeItems: "center" }}>
+                  <span>Нет фото</span>
+                </div>
+              )}
+            </div>
+
+            <div style={{ flex: 1 }}>
+              <p><b>Имя пользователя:</b> {profile.username}</p>
+              <p><b>Email:</b> {profile.email}</p>
+              <p><b>Имя:</b> {profile.first_name || "—"}</p>
+              <p><b>Фамилия:</b> {profile.last_name || "—"}</p>
+              <p><b>О себе:</b> {profile.bio || "—"}</p>
+
+              <button className="btn" onClick={onEdit}>Редактировать</button>
+            </div>
           </div>
-          <div className="file-path-wrapper">
-            <input className="file-path validate" type="text" />
+        </>
+      )}
+
+      {/* Режим редактирования */}
+      {edit && (
+        <form onSubmit={onSave}>
+          <div style={{ display: "flex", gap: 24, alignItems: "flex-start" }}>
+            <div>
+              {avatarSrc ? (
+                <img
+                  src={avatarSrc}
+                  alt="avatar"
+                  style={{ width: 132, height: 132, borderRadius: "50%", objectFit: "cover", border: "1px solid #eee" }}
+                />
+              ) : (
+                <div style={{ width: 132, height: 132, borderRadius: "50%", background: "#f2f2f2", display: "grid", placeItems: "center" }}>
+                  <span>Нет фото</span>
+                </div>
+              )}
+              <div className="file-field input-field" style={{ marginTop: 8 }}>
+                <div className="btn">
+                  <span>Фото</span>
+                  <input type="file" accept="image/*" onChange={onFile} />
+                </div>
+                <div className="file-path-wrapper">
+                  <input className="file-path validate" type="text" readOnly />
+                </div>
+                {profile.photo && !file && (
+                  <button type="button" className="btn-flat" onClick={onRemovePhoto} style={{ marginTop: 8 }}>
+                    Удалить текущее фото
+                  </button>
+                )}
+              </div>
+            </div>
+
+            <div style={{ flex: 1 }}>
+              <div className="input-field">
+                <input id="first_name" name="first_name" value={form.first_name} onChange={onChange} />
+                <label className="active" htmlFor="first_name">Имя</label>
+              </div>
+
+              <div className="input-field">
+                <input id="last_name" name="last_name" value={form.last_name} onChange={onChange} />
+                <label className="active" htmlFor="last_name">Фамилия</label>
+              </div>
+
+              <div className="input-field">
+                <textarea
+                  id="bio"
+                  name="bio"
+                  className="materialize-textarea"
+                  value={form.bio}
+                  onChange={onChange}
+                  rows={4}
+                />
+                <label className="active" htmlFor="bio">Описание</label>
+              </div>
+
+              {error && (
+                <div style={{ color: "crimson", margin: "6px 0" }}>
+                  {typeof error === "string" ? error : JSON.stringify(error)}
+                </div>
+              )}
+
+              <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
+                <button className="btn" type="submit" disabled={saving}>
+                  {saving ? "Сохранение…" : "Сохранить"}
+                </button>
+                <button className="btn-flat" type="button" onClick={onCancel} disabled={saving}>
+                  Отмена
+                </button>
+              </div>
+            </div>
           </div>
-        </div>
-        <button className="btn" type="submit">Сохранить</button>
-      </form>
+        </form>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Что сделано: просмотр профиля без инпутов, режим редактирования, загрузка/удаление фото, абсолютный URL фото, PATCH + multipart.

Файлы: frontend/src/components/Profile.js, frontend/src/api.js, backend/accounts/serializers.py, backend/accounts/views.py, backend/pytest.ini.

Проверка: логин → профиль, видны данные/фото; «Редактировать» → появляются поля и загрузка фото; «Сохранить» → обновление; «Удалить текущее фото» → фото очищается.