### PR TITLE
Use description field for news

### DIFF
--- a/frontend/src/components/NewsDetail.js
+++ b/frontend/src/components/NewsDetail.js
@@ -28,7 +28,7 @@ function NewsDetail() {
       {news.image && (
         <img src={news.image} alt={news.title} className="news-detail-image" />
       )}
-      <p className="news-detail-text">{news.content}</p>
+      <p className="news-detail-text">{news.description || news.content}</p>
       {news.author && (
         <p className="news-meta">Автор: {news.author}, {news.date}</p>
       )}

--- a/frontend/src/components/NewsList.js
+++ b/frontend/src/components/NewsList.js
@@ -45,7 +45,7 @@ function NewsList() {
                 {n.title}
               </a>
             </span>
-            <p>{n.content?.slice(0, 150)}...</p>
+            {n.description && <p>{n.description}</p>}
           </div>
           <div className="card-action">
             <a


### PR DESCRIPTION
## Summary
- replace content snippet with source description in news list
- fall back to description in news detail view

## Testing
- `CI=true npm test --silent` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68bb15f247748331b443bcb7d54bfc1f